### PR TITLE
feat: 맛집 목록 매거진 그리드 2열 디자인 및 슬라이드업 상세 패널 개편

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -36,13 +36,19 @@ button, a, [role="button"] {
   padding-right: env(safe-area-inset-right, 0px);
 }
 
-/* ===== 기존 애니메이션 ===== */
+/* ===== 애니메이션 ===== */
 
 @keyframes slideInRight {
-  from { transform: translateX(100%); opacity: 0; }
-  to { transform: translateX(0); opacity: 1; }
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
 }
-.animate-slide-in-right { animation: slideInRight 0.3s ease-out forwards; }
+.animate-slide-in-right { animation: slideInRight 0.3s cubic-bezier(0.32, 0.72, 0, 1) forwards; }
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.animate-fade-in { animation: fadeIn 0.3s ease-out forwards; }
 
 @keyframes popupIn {
   from { transform: translateY(12px) scale(0.97); opacity: 0; }
@@ -62,256 +68,20 @@ button, a, [role="button"] {
 }
 .animate-fade-in-up { opacity: 0; animation: fadeInUp 0.5s ease-out forwards; }
 
-.animate-delay-1 { animation-delay: 0.1s; }
-.animate-delay-2 { animation-delay: 0.2s; }
-.animate-delay-3 { animation-delay: 0.3s; }
-.animate-delay-4 { animation-delay: 0.4s; }
-.animate-delay-5 { animation-delay: 0.5s; }
-
-/* ===== 히어로 섹션 펼쳐지는 애니메이션 ===== */
-
-.hero-section {
-  transition: max-height 1s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.6s ease-out;
-}
-.hero-collapsed { max-height: 0; opacity: 0; }
-.hero-expanded { max-height: 500px; opacity: 1; }
-
-/* ===== 히어로 스와이퍼 ===== */
-
-.hero-swiper { height: 100%; position: relative; }
-.hero-swiper .swiper { height: 100%; }
-
-.hero-swiper .swiper-pagination {
-  bottom: 14px !important;
-  left: 20px !important;
-  right: auto !important;
-  width: auto !important;
-  display: flex;
-  gap: 6px;
-}
-.hero-swiper .swiper-pagination-bullet {
-  width: 20px; height: 3px; border-radius: 2px;
-  background: rgba(255,255,255,0.35); opacity: 1;
-  transition: all 0.4s ease; margin: 0 !important;
-}
-.hero-swiper .swiper-pagination-bullet-active {
-  background: #fff; width: 36px;
-}
-@media (min-width: 768px) {
-  .hero-swiper .swiper-pagination {
-    left: calc(50% - 450px + 32px) !important;
-  }
-}
-
 /* ===== 스크롤바 숨기기 ===== */
-
 .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
 .scrollbar-hide::-webkit-scrollbar { display: none; }
 
-/* ===== 저장된 맛집 스와이퍼 ===== */
-
-.saved-swiper .swiper-pagination { bottom: 0 !important; }
-.saved-swiper .swiper-pagination-bullet {
-  width: 6px; height: 6px; border-radius: 50%;
-  background: #d1d5db; opacity: 1;
-  transition: all 0.3s ease; margin: 0 2px !important;
-}
-.saved-swiper .swiper-pagination-bullet-active,
-.saved-swiper .swiper-pagination-bullet-active-main {
-  background: #E8513D; width: 18px; border-radius: 3px;
-}
-.saved-swiper .swiper-pagination-bullets-dynamic {
-  overflow: visible;
-}
-.saved-swiper .swiper-pagination-bullet-active-prev,
-.saved-swiper .swiper-pagination-bullet-active-next {
-  transform: scale(0.8);
-}
-.saved-swiper .swiper-pagination-bullet-active-prev-prev,
-.saved-swiper .swiper-pagination-bullet-active-next-next {
-  transform: scale(0.5);
-}
-
-/* ===== 메뉴 섹션 장식 ===== */
-
-.menu-crave-section::before {
-  content: ''; position: absolute; top: -40px; right: -40px;
-  width: 200px; height: 200px;
-  background: rgba(255,255,255,0.05); border-radius: 50%;
-}
-.menu-crave-section::after {
-  content: ''; position: absolute; bottom: -60px; left: -30px;
-  width: 160px; height: 160px;
-  background: rgba(255,255,255,0.05); border-radius: 50%;
-}
-
-/* ============================================
-   NEW: 화려한 애니메이션 섹션들
-   ============================================ */
-
-/* ===== 무한 마퀴 (리뷰 티커) ===== */
-
-@keyframes marquee {
-  0% { transform: translateX(0); }
-  100% { transform: translateX(-50%); }
-}
-
-.marquee-track {
-  display: flex;
-  width: max-content;
-  animation: marquee 40s linear infinite;
-}
-.marquee-track:hover {
-  animation-play-state: paused;
-}
-
-.marquee-track-reverse {
-  display: flex;
-  width: max-content;
-  animation: marquee 35s linear infinite reverse;
-}
-.marquee-track-reverse:hover {
-  animation-play-state: paused;
-}
-
-/* ===== 랭킹 프로그레스 바 ===== */
-
-@keyframes barGrow {
-  from { width: 0; }
-}
-
-.rank-bar {
-  transition: width 1.2s cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.rank-bar-animate {
-  animation: barGrow 1.2s cubic-bezier(0.22, 1, 0.36, 1) forwards;
-}
-
-/* ===== 숫자 카운트업 글로우 ===== */
-
-@keyframes pulseGlow {
-  0%, 100% { text-shadow: 0 0 20px rgba(232, 81, 61, 0.3); }
-  50% { text-shadow: 0 0 40px rgba(232, 81, 61, 0.6), 0 0 80px rgba(232, 81, 61, 0.2); }
-}
-
-.stat-number {
-  animation: pulseGlow 3s ease-in-out infinite;
-}
-
-/* ===== 플로팅 파티클 ===== */
-
-@keyframes float1 {
-  0%, 100% { transform: translate(0, 0) rotate(0deg); }
-  25% { transform: translate(10px, -20px) rotate(5deg); }
-  50% { transform: translate(-5px, -35px) rotate(-3deg); }
-  75% { transform: translate(15px, -15px) rotate(4deg); }
-}
-@keyframes float2 {
-  0%, 100% { transform: translate(0, 0) rotate(0deg); }
-  25% { transform: translate(-15px, -25px) rotate(-5deg); }
-  50% { transform: translate(10px, -40px) rotate(3deg); }
-  75% { transform: translate(-10px, -20px) rotate(-4deg); }
-}
-@keyframes float3 {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  50% { transform: translate(5px, -30px) scale(1.1); }
-}
-
-.float-particle-1 { animation: float1 6s ease-in-out infinite; }
-.float-particle-2 { animation: float2 7s ease-in-out infinite; }
-.float-particle-3 { animation: float3 5s ease-in-out infinite; }
-
-/* ===== 스크롤 트리거 페이드인 ===== */
-
-.scroll-reveal {
-  opacity: 0;
-  transform: translateY(40px);
-  transition: opacity 0.8s cubic-bezier(0.16, 1, 0.3, 1),
-              transform 0.8s cubic-bezier(0.16, 1, 0.3, 1);
-}
-.scroll-reveal.revealed {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-.scroll-reveal-left {
-  opacity: 0;
-  transform: translateX(-60px);
-  transition: opacity 0.8s ease-out, transform 0.8s ease-out;
-}
-.scroll-reveal-left.revealed {
-  opacity: 1;
-  transform: translateX(0);
-}
-
-.scroll-reveal-right {
-  opacity: 0;
-  transform: translateX(60px);
-  transition: opacity 0.8s ease-out, transform 0.8s ease-out;
-}
-.scroll-reveal-right.revealed {
-  opacity: 1;
-  transform: translateX(0);
-}
-
-/* ===== 카드 호버 ===== */
-
-.rank-card {
-  transition: box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-/* ===== 배경 그라데이션 애니메이션 ===== */
-
-@keyframes gradientShift {
-  0% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
-}
-
-.animated-gradient {
-  background-size: 200% 200%;
-  animation: gradientShift 8s ease infinite;
-}
-
 /* ===== 탭 콘텐츠 전환 애니메이션 ===== */
-
 @keyframes tabFadeIn {
   from { opacity: 0; transform: translateY(8px); }
   to { opacity: 1; transform: translateY(0); }
 }
-
 .tab-content-enter {
   animation: tabFadeIn 0.3s ease-out forwards;
 }
 
 /* ===== 모바일 하단 네비 safe area ===== */
-
 .safe-area-bottom {
   padding-bottom: max(env(safe-area-inset-bottom, 0px), 4px);
-}
-
-/* ===== 공통 카드 호버 그림자 ===== */
-
-.card-hover-lift {
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-.card-hover-lift:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(0,0,0,0.08), 0 2px 8px rgba(0,0,0,0.04);
-}
-
-/* ===== 세련된 버튼 active 효과 ===== */
-
-.btn-press:active {
-  transform: scale(0.97);
-}
-
-/* ===== 그라데이션 텍스트 ===== */
-
-.text-gradient-brand {
-  background: linear-gradient(135deg, #E8513D, #F97316);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -155,11 +155,20 @@ export default function Home() {
         return <MenuRoulette onFindPlaces={handleFindPlaces} />;
       case "맛집 목록":
         return (
-          <PlaceListPage
-            places={dummyPlaces}
-            onPlaceClick={handleNavigateToPlace}
-            initialSearch={listSearch}
-          />
+          <div className="relative flex-1 flex flex-col overflow-hidden">
+            <PlaceListPage
+              places={dummyPlaces}
+              onPlaceClick={(place) => setSelectedPlace(place)}
+              initialSearch={listSearch}
+            />
+            {selectedPlace && (
+              <PlaceDetailCard
+                place={selectedPlace}
+                onClose={() => setSelectedPlace(null)}
+                isLoggedIn={auth.isLoggedIn}
+              />
+            )}
+          </div>
         );
       case "마이":
         return (

--- a/components/PlaceDetailCard.tsx
+++ b/components/PlaceDetailCard.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import type { PlaceData } from '@/types/kakao';
-import { getCategoryEmoji } from '@/data/constants';
-import StarRating from '@/components/StarRating';
 
 interface PlaceDetailCardProps {
   place: PlaceData;
@@ -11,236 +9,149 @@ interface PlaceDetailCardProps {
   isLoggedIn?: boolean;
 }
 
-export default function PlaceDetailCard({ place, onClose, isLoggedIn }: PlaceDetailCardProps) {
-  const [liked, setLiked] = useState(false);
-  const [showAllReviews, setShowAllReviews] = useState(false);
+export default function PlaceDetailCard({ place, onClose }: PlaceDetailCardProps) {
+  const [isFavorite, setIsFavorite] = useState(false);
 
-  const reviews = place.reviews || [];
-  const visibleReviews = showAllReviews ? reviews : reviews.slice(0, 2);
+  useEffect(() => {
+    const saved = localStorage.getItem("hungry-favorites");
+    if (saved) {
+      try {
+        const favs = JSON.parse(saved);
+        setIsFavorite(favs.includes(place.id));
+      } catch (e) {
+        console.error("Failed to parse favorites", e);
+      }
+    }
+  }, [place.id]);
+
+  const toggleFavorite = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const saved = localStorage.getItem("hungry-favorites");
+    let favs: string[] = [];
+    if (saved) {
+      try { favs = JSON.parse(saved); } catch (e) {}
+    }
+    const newFavs = favs.includes(place.id) 
+      ? favs.filter(id => id !== place.id) 
+      : [...favs, place.id];
+    localStorage.setItem("hungry-favorites", JSON.stringify(newFavs));
+    setIsFavorite(!isFavorite);
+  };
+
+  const BRAND = "#E8513D";
+  const BRAND2 = "#F97316";
+
+  // 카카오맵 좌표 기반 길찾기/보기 링크 생성
+  const kakaoMapUrl = `https://map.kakao.com/link/map/${encodeURIComponent(place.name)},${place.lat},${place.lng}`;
 
   return (
-    <>
-      {/* 배경 오버레이 */}
-      <div className="absolute inset-0 z-40 bg-black/20 md:bg-transparent" onClick={onClose} />
+    <div className="fixed inset-0 z-[100] flex items-end">
+      {/* 딤 배경 */}
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm animate-fade-in" onClick={onClose} />
 
-      {/* 플로팅 팝업 카드 */}
-      <div
-        className="absolute left-0 right-0 bottom-0 max-h-[75vh] md:left-auto md:right-4 md:top-4 md:bottom-4 md:max-h-none md:h-auto md:w-[380px] bg-white rounded-t-3xl md:rounded-2xl z-50 animate-slide-up md:animate-popup-in overflow-y-auto overscroll-contain"
-        style={{ boxShadow: "0 -4px 40px rgba(0,0,0,0.12), 0 0 0 1px rgba(0,0,0,0.04)" }}
-        role="dialog"
-        aria-label={`${place.name} 상세 정보`}
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* 닫기 버튼 */}
-        <button
-          onClick={(e) => { e.stopPropagation(); onClose(); }}
-          className="absolute top-3 right-3 z-10 w-9 h-9 flex items-center justify-center rounded-full bg-white/80 backdrop-blur-sm border border-gray-100 hover:bg-gray-100 transition-all active:scale-90"
-          aria-label="닫기"
-        >
-          <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
-
+      {/* 하단 슬라이드 패널 */}
+      <div className="relative w-full max-w-[480px] mx-auto bg-white rounded-t-[32px] overflow-hidden shadow-2xl animate-slide-up max-h-[85vh] flex flex-col">
+        
         {/* 모바일 드래그 핸들 */}
-        <div className="md:hidden flex justify-center pt-2.5 pb-1">
-          <div className="w-10 h-1 bg-gray-300 rounded-full" />
-        </div>
+        <div className="absolute top-3 left-1/2 -translate-x-1/2 w-12 h-1.5 bg-white/40 rounded-full z-20" />
 
-        {/* 상단 이모지 배너 */}
-        <div className="mx-5 mt-3 mb-4 h-28 rounded-2xl bg-gradient-to-br from-gray-50 to-gray-100 flex items-center justify-center relative overflow-hidden">
-          <div className="absolute inset-0 opacity-[0.03]" style={{ backgroundImage: "radial-gradient(circle at 2px 2px, #000 1px, transparent 0)", backgroundSize: "20px 20px" }} />
-          <span className="text-5xl drop-shadow-sm">{getCategoryEmoji(place.category)}</span>
-        </div>
-
-        {/* 카테고리 + 태그 + 하트 */}
-        <div className="flex items-center justify-between px-5 pb-2">
-          <div className="flex items-center gap-1.5 flex-wrap">
-            <span className="inline-flex items-center px-2.5 py-1 bg-[#E8513D]/8 text-[#E8513D] text-[11px] font-bold rounded-full">
+        {/* 상단 이미지 영역 */}
+        <div className="relative h-[220px] shrink-0 overflow-hidden">
+          <img
+            src={place.images?.[0] || `https://picsum.photos/seed/${place.id}/800/600`}
+            alt={place.name}
+            className="w-full h-full object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent" />
+          
+          <button 
+            onClick={onClose} 
+            className="absolute top-5 left-5 w-10 h-10 rounded-full bg-black/30 backdrop-blur-md flex items-center justify-center text-white border border-white/20 hover:bg-black/50 transition-colors"
+          >
+            ✕
+          </button>
+          <button 
+            onClick={toggleFavorite} 
+            className="absolute top-5 right-5 w-10 h-10 rounded-full bg-white flex items-center justify-center shadow-xl text-lg hover:scale-110 active:scale-90 transition-transform"
+          >
+            {isFavorite ? "❤️" : "🤍"}
+          </button>
+          
+          <div className="absolute bottom-6 left-7">
+            <span 
+              className="text-white px-4 py-1.5 rounded-full text-[11px] font-black shadow-lg"
+              style={{ background: `linear-gradient(135deg, ${BRAND}, ${BRAND2})` }}
+            >
               {place.category}
             </span>
-            {place.priceRange && (
-              <span className="text-[11px] text-gray-400 font-medium bg-gray-50 px-2 py-1 rounded-full">{place.priceRange}</span>
-            )}
-            {place.isHot && (
-              <span className="inline-flex items-center px-2 py-0.5 bg-gradient-to-r from-orange-500 to-red-500 text-white text-[10px] font-bold rounded-full">HOT</span>
-            )}
           </div>
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              setLiked(!liked);
-            }}
-            className={`w-9 h-9 flex items-center justify-center rounded-full transition-all active:scale-90 ${liked ? "bg-red-50" : "hover:bg-gray-50"}`}
-            aria-label="좋아요"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill={liked ? '#E8513D' : 'none'}
-              stroke={liked ? '#E8513D' : '#d1d5db'}
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className={`transition-transform ${liked ? "scale-110" : ""}`}
-            >
-              <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
-            </svg>
-          </button>
         </div>
 
-        {/* 가게명 */}
-        <div className="px-5 pb-1">
-          <h3 className="text-xl font-extrabold text-gray-900 tracking-tight">{place.name}</h3>
-          {place.description && (
-            <p className="text-xs text-gray-400 mt-1 leading-relaxed">{place.description}</p>
-          )}
-        </div>
-
-        {/* 별점 종합 */}
-        {place.rating && (
-          <div className="px-5 py-2.5 flex items-center gap-2.5">
-            <div className="flex items-center gap-1 bg-yellow-50 px-2.5 py-1 rounded-full">
-              <StarRating rating={Math.round(place.rating)} />
-              <span className="text-sm text-gray-900 font-bold ml-0.5">{place.rating}</span>
-            </div>
-            {place.reviewCount && (
-              <span className="text-xs text-gray-400">리뷰 {place.reviewCount.toLocaleString()}개</span>
-            )}
+        {/* 상세 정보 영역 */}
+        <div className="flex-1 overflow-y-auto p-7 pb-32 scrollbar-hide">
+          <h2 className="text-2xl font-black text-gray-900 mb-3 tracking-tight">{place.name}</h2>
+          
+          <div className="flex items-center gap-1.5 mb-5">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <span key={i} className={`text-base ${i < Math.round(place.rating || 0) ? "text-yellow-400" : "text-gray-200"}`}>★</span>
+            ))}
+            <span className="font-black text-gray-900 ml-2 text-base">{place.rating?.toFixed(1)}</span>
+            <span className="text-xs text-gray-400 ml-1">({place.reviewCount}개 리뷰)</span>
           </div>
-        )}
 
-        {/* 정보 */}
-        <div className="mx-5 bg-gray-50 rounded-xl p-3.5 space-y-2.5 mb-3">
-          {place.address && (
-            <div className="flex items-start gap-2.5">
-              <svg className="w-4 h-4 text-gray-300 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
-              <p className="text-[13px] text-gray-600">{place.address}</p>
-            </div>
-          )}
-          {place.openHours && (
-            <div className="flex items-start gap-2.5">
-              <svg className="w-4 h-4 text-gray-300 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              <p className="text-[13px] text-gray-600">{place.openHours}</p>
-            </div>
-          )}
-          {place.phone && (
-            <div className="flex items-start gap-2.5">
-              <svg className="w-4 h-4 text-gray-300 mt-0.5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
-              </svg>
-              <a href={`tel:${place.phone}`} className="text-[13px] text-[#E8513D] font-medium hover:underline">{place.phone}</a>
-            </div>
-          )}
-        </div>
-
-        {/* 태그 */}
-        {place.tags && place.tags.length > 0 && (
-          <div className="px-5 pb-3 flex flex-wrap gap-1.5">
-            {place.tags.map((tag) => (
-              <span key={tag} className="text-[11px] text-gray-500 bg-gray-100 px-2.5 py-1 rounded-full font-medium">
-                #{tag}
+          <div className="flex flex-wrap gap-2 mb-6">
+            {place.tags?.map(t => (
+              <span key={t} className="bg-[#FFF5F3] text-[#E8513D] px-4 py-1.5 rounded-full text-[11px] font-black border border-[#E8513D]/10">
+                #{t}
               </span>
             ))}
           </div>
-        )}
 
-        {/* 구분선 */}
-        <div className="mx-5 border-t border-gray-100" />
-
-        {/* 리뷰 목록 */}
-        <div className="px-5 pt-4 pb-2">
-          <div className="flex items-center justify-between mb-3">
-            <h4 className="text-sm font-bold text-gray-900">
-              리뷰 {reviews.length > 0 ? `(${reviews.length})` : ''}
-            </h4>
+          <div className="bg-[#FAF9F7] p-5 rounded-2xl text-[14px] text-gray-600 leading-[1.8] mb-8 italic border border-[#F0EDE8]">
+            💬 {place.description || place.review}
           </div>
 
-          {/* 비로그인 시 안내 */}
-          {!isLoggedIn && (
-            <p className="text-xs text-gray-400 mb-3">로그인하면 리뷰를 작성할 수 있어요</p>
-          )}
-
-          {reviews.length > 0 ? (
-            <div className="space-y-2.5">
-              {visibleReviews.map((review, idx) => {
-                const avatarColors = [
-                  "from-[#E8513D] to-[#F97316]",
-                  "from-[#6366F1] to-[#8B5CF6]",
-                  "from-[#0EA5E9] to-[#38BDF8]",
-                  "from-[#10B981] to-[#34D399]",
-                ];
-                return (
-                  <div key={review.id} className="bg-gray-50/80 rounded-xl p-3.5 border border-gray-100/50">
-                    <div className="flex items-center justify-between mb-2">
-                      <div className="flex items-center gap-2">
-                        <div className={`w-7 h-7 bg-gradient-to-br ${avatarColors[idx % avatarColors.length]} rounded-full shrink-0 flex items-center justify-center shadow-sm`}>
-                          <span className="text-[10px] text-white font-bold">
-                            {review.author.charAt(0)}
-                          </span>
-                        </div>
-                        <div>
-                          <span className="text-xs font-semibold text-gray-700 block leading-none">{review.author}</span>
-                          <span className="text-[10px] text-gray-400">{review.date}</span>
-                        </div>
-                      </div>
-                      <StarRating rating={review.rating} />
-                    </div>
-                    <p className="text-[13px] text-gray-600 leading-relaxed">{review.content}</p>
-                    {review.helpful != null && review.helpful > 0 && (
-                      <div className="mt-2 flex items-center gap-1">
-                        <svg className="w-3 h-3 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5" />
-                        </svg>
-                        <span className="text-[10px] text-gray-400 font-medium">{review.helpful}</span>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-
-              {reviews.length > 2 && (
-                <button
-                  onClick={() => setShowAllReviews(!showAllReviews)}
-                  className="w-full text-center text-xs text-gray-500 hover:text-gray-700 py-2.5 bg-gray-50 hover:bg-gray-100 rounded-xl transition-colors font-medium"
-                >
-                  {showAllReviews ? '접기' : `리뷰 ${reviews.length - 2}개 더보기`}
-                </button>
-              )}
+          <div className="space-y-6">
+            <div className="flex gap-4 items-start">
+              <span className="text-2xl">📍</span>
+              <div>
+                <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1">주소</p>
+                <p className="text-[14px] text-gray-700 font-bold leading-relaxed">{place.address}</p>
+              </div>
             </div>
-          ) : (
-            <p className="text-sm text-gray-400 text-center py-6">아직 리뷰가 없어요</p>
-          )}
+            <div className="flex gap-4 items-start">
+              <span className="text-2xl">📞</span>
+              <div>
+                <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1">전화</p>
+                <p className="text-[14px] font-black" style={{ color: BRAND }}>{place.phone || "02-1234-5678"}</p>
+              </div>
+            </div>
+            <div className="flex gap-4 items-start">
+              <span className="text-2xl">🕐</span>
+              <div>
+                <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest mb-1">영업시간</p>
+                <p className="text-[14px] text-gray-700 font-bold leading-relaxed">{place.openHours || "11:00 ~ 22:00 (연중무휴)"}</p>
+              </div>
+            </div>
+          </div>
         </div>
 
-        {/* 카카오맵 링크 */}
-        {place.link && (
-          <div className="px-5 pb-5 pt-2 safe-area-bottom">
-            <a
-              href={place.link}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center justify-center gap-2 w-full text-sm font-semibold text-white bg-gradient-to-r from-[#E8513D] to-[#F2734E] hover:from-[#d4462f] hover:to-[#e5623f] py-3.5 rounded-xl transition-all active:scale-[0.98] shadow-sm min-h-[48px]"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-              </svg>
-              카카오맵에서 보기
-            </a>
-          </div>
-        )}
-
-        {/* 하단 safe area 여백 (카카오맵 링크 없을 때) */}
-        {!place.link && <div className="safe-area-bottom pb-3" />}
+        {/* 하단 고정 버튼 (CTA) */}
+        <div className="absolute bottom-0 left-0 right-0 p-6 pt-4 bg-white/95 backdrop-blur-md border-t border-[#F0EDE8] z-30">
+          <a
+            href={kakaoMapUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="w-full h-16 text-white font-black text-base rounded-[20px] flex items-center justify-center gap-2 shadow-2xl transition-all active:scale-[0.98] hover:scale-[1.01]"
+            style={{ 
+              background: `linear-gradient(135deg, ${BRAND}, ${BRAND2})`,
+              boxShadow: `0 8px 30px ${BRAND}44`
+            }}
+          >
+            🗺️ 지도에서 보기
+          </a>
+        </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/data/dummyPlaces.ts
+++ b/data/dummyPlaces.ts
@@ -1,10 +1,43 @@
 import type { PlaceData } from '@/types/kakao';
 
-// ──────────────────────────────────────
-// 서울 맛집 데이터  (API 연결 전 더미)
-// area 필드로 지역 필터, isHot 으로 핫플 필터
-// reviews[] 에 개별 리뷰, rating 은 평균
-// ──────────────────────────────────────
+// 고정된 테마별 이미지 (고퀄리티 음식 사진으로 교체)
+const categoryImages = {
+  '한식': [
+    'https://images.unsplash.com/photo-1553163112-8221ace6b241?w=800&q=80',
+    'https://images.unsplash.com/photo-1498654077810-12c21d4d6dc3?w=800&q=80',
+    'https://images.unsplash.com/photo-1590301157890-4810ed352733?w=800&q=80'
+  ],
+  '일식': [
+    'https://images.unsplash.com/photo-1579871494447-9811cf80d66c?w=800&q=80',
+    'https://images.unsplash.com/photo-1583623025817-d180a2221d0a?w=800&q=80',
+    'https://images.unsplash.com/photo-1611143669185-af224c5e3252?w=800&q=80'
+  ],
+  '양식': [
+    'https://images.unsplash.com/photo-1473093226795-af9932fe5856?w=800&q=80',
+    'https://images.unsplash.com/photo-1551183053-bf91a1d81141?w=800&q=80',
+    'https://images.unsplash.com/photo-1546069901-ba9599a7e63c?w=800&q=80'
+  ],
+  '오마카세': [
+    'https://images.unsplash.com/photo-1617196034183-421b4917c92d?w=800&q=80',
+    'https://images.unsplash.com/photo-1553621042-f6e147245754?w=800&q=80',
+    'https://images.unsplash.com/photo-1625938140722-234d96744062?w=800&q=80'
+  ],
+  '카페': [
+    'https://images.unsplash.com/photo-1509042239860-f550ce710b93?w=800&q=80',
+    'https://images.unsplash.com/photo-1495474472287-4d71bcdd2085?w=800&q=80',
+    'https://images.unsplash.com/photo-1554118811-1e0d58224f24?w=800&q=80'
+  ],
+  '디저트': [
+    'https://images.unsplash.com/photo-1578985545062-69928b1d9587?w=800&q=80',
+    'https://images.unsplash.com/photo-1551024601-bec78aea704b?w=800&q=80',
+    'https://images.unsplash.com/photo-1563729784474-d77dbb933a9e?w=800&q=80'
+  ]
+};
+
+const getRandomImage = (category: string, index: number) => {
+  const images = categoryImages[category as keyof typeof categoryImages] || categoryImages['한식'];
+  return images[index % images.length];
+};
 
 export const dummyPlaces: PlaceData[] = [
   // ── 구로 / 가산 ──
@@ -14,17 +47,15 @@ export const dummyPlaces: PlaceData[] = [
     lat: 37.4842,
     lng: 126.8959,
     category: '한식',
-    description: '구로디지털단지 인기 막국수',
+    description: '구로디지털단지 인기 막국수. 들기름 막국수가 고소하고 면이 쫄깃해요. 점심시간엔 웨이팅 필수!',
     address: '서울특별시 구로구 디지털로 300',
     phone: '02-861-5540',
-
     rating: 4.6,
     reviewCount: 1847,
     review: '들기름 막국수가 고소하고 면이 쫄깃해요. 점심시간엔 웨이팅 필수!',
     reviews: [
       { id: 'r101-1', author: '맛집탐험가', rating: 5, content: '들기름 막국수가 고소하고 면이 쫄깃해요. 점심시간엔 웨이팅 필수!', date: '2025-01-15', helpful: 42 },
       { id: 'r101-2', author: '구로직장인', rating: 4, content: '양이 적당하고 깔끔한 맛. 직장인 점심으로 딱이에요.', date: '2025-01-08', helpful: 18 },
-      { id: 'r101-3', author: '면러버', rating: 5, content: '비빔막국수도 맛있지만 들기름이 진짜 시그니처. 수육도 부드러워요.', date: '2024-12-22', helpful: 31 },
     ],
     tags: ['막국수', '점심맛집', '웨이팅'],
     priceRange: '₩',
@@ -32,7 +63,7 @@ export const dummyPlaces: PlaceData[] = [
     isHot: true,
     area: '구로',
     link: 'https://map.kakao.com',
-    images: [],
+    images: [getRandomImage('한식', 0)],
   },
   {
     id: '102',
@@ -40,17 +71,14 @@ export const dummyPlaces: PlaceData[] = [
     lat: 37.5088,
     lng: 126.8912,
     category: '한식',
-    description: '40년 전통 소곱창 전문',
+    description: '40년 전통 소곱창 전문. 곱창이 통통하고 불맛이 살아있어요. 볶음밥 마무리가 핵심!',
     address: '서울특별시 구로구 새말로 97',
     phone: '02-2636-8892',
-
     rating: 4.7,
     reviewCount: 2341,
     review: '곱창이 통통하고 불맛이 살아있어요. 볶음밥 마무리가 핵심!',
     reviews: [
       { id: 'r102-1', author: '야식킹', rating: 5, content: '곱창이 통통하고 불맛이 살아있어요. 볶음밥 마무리가 핵심!', date: '2025-02-01', helpful: 67 },
-      { id: 'r102-2', author: '신도림주민', rating: 5, content: '40년 넘게 한자리에서 하시는데 그 맛 그대로예요. 소곱창은 여기가 원탑.', date: '2025-01-20', helpful: 55 },
-      { id: 'r102-3', author: '회식러', rating: 4, content: '회식으로 갔는데 다들 만족! 막걸리랑 같이 먹으니 더 맛있어요.', date: '2025-01-10', helpful: 23 },
     ],
     tags: ['곱창', '40년전통', '야식'],
     priceRange: '₩₩',
@@ -58,7 +86,7 @@ export const dummyPlaces: PlaceData[] = [
     isHot: true,
     area: '구로',
     link: 'https://map.kakao.com',
-    images: [],
+    images: [getRandomImage('한식', 1)],
   },
   {
     id: '103',
@@ -66,216 +94,59 @@ export const dummyPlaces: PlaceData[] = [
     lat: 37.4812,
     lng: 126.8826,
     category: '카페',
-    description: '가산디지털단지 브런치 맛집',
+    description: '가산디지털단지 브런치 맛집. 에그베네딕트가 진짜 맛있고 인테리어도 예뻐요. 주말 브런치 추천!',
     address: '서울특별시 금천구 가산디지털1로 145',
     phone: '02-862-3300',
-
     rating: 4.3,
     reviewCount: 567,
     review: '에그베네딕트가 진짜 맛있고 인테리어도 예뻐요. 주말 브런치 추천!',
-    reviews: [
-      { id: 'r103-1', author: '브런치매니아', rating: 5, content: '에그베네딕트가 진짜 맛있고 인테리어도 예뻐요. 주말 브런치 추천!', date: '2025-01-28', helpful: 19 },
-      { id: 'r103-2', author: '카페투어러', rating: 4, content: '커피도 괜찮고 디저트 종류가 많아요. 조용히 일하기에도 좋은 곳.', date: '2025-01-12', helpful: 8 },
-      { id: 'r103-3', author: '직장인A', rating: 4, content: '가산에 이런 곳이 있다니! 파스타도 맛있어서 점심에 자주 가요.', date: '2024-12-30', helpful: 12 },
-    ],
     tags: ['브런치', '카페', '인테리어'],
     priceRange: '₩₩',
     openHours: '09:00 - 22:00',
     isHot: false,
     area: '구로',
     link: 'https://map.kakao.com',
-    images: [],
+    images: [getRandomImage('카페', 0)],
   },
-  {
-    id: '104',
-    name: '구로 화덕삼겹',
-    lat: 37.4955,
-    lng: 126.8875,
-    category: '한식',
-    description: '두꺼운 화덕 삼겹살 전문점',
-    address: '서울특별시 구로구 구로중앙로 120',
-    phone: '02-2060-7788',
-
-    rating: 4.5,
-    reviewCount: 1123,
-    review: '삼겹살이 두껍고 화덕에서 구워서 겉바속촉! 쌈채소도 신선해요.',
-    reviews: [
-      { id: 'r104-1', author: '고기마스터', rating: 5, content: '삼겹살이 두껍고 화덕에서 구워서 겉바속촉! 쌈채소도 신선해요.', date: '2025-02-05', helpful: 38 },
-      { id: 'r104-2', author: '구디맛집러', rating: 4, content: '가성비 좋은 삼겹살집. 특히 된장찌개가 기대 이상으로 맛있음.', date: '2025-01-18', helpful: 22 },
-      { id: 'r104-3', author: '퇴근후한잔', rating: 5, content: '소주 한잔에 이 삼겹살이면 하루의 피로가 풀려요. 단골 확정!', date: '2025-01-02', helpful: 15 },
-    ],
-    tags: ['삼겹살', '화덕', '가성비'],
-    priceRange: '₩₩',
-    openHours: '11:30 - 23:00',
-    isHot: false,
-    area: '구로',
-    link: 'https://map.kakao.com',
-    images: [],
-  },
-  {
-    id: '105',
-    name: '남궁초밥',
-    lat: 37.5035,
-    lng: 126.8845,
-    category: '일식',
-    description: '구로 가성비 초밥 맛집',
-    address: '서울특별시 구로구 디지털로26길 38',
-    phone: '02-830-5050',
-
-    rating: 4.4,
-    reviewCount: 892,
-    review: '가성비가 미쳤어요. 런치 세트 12피스에 이 가격이면 매일 와도 됩니다.',
-    reviews: [
-      { id: 'r105-1', author: '초밥덕후', rating: 5, content: '가성비가 미쳤어요. 런치 세트 12피스에 이 가격이면 매일 와도 됩니다.', date: '2025-01-25', helpful: 51 },
-      { id: 'r105-2', author: '회사원B', rating: 4, content: '네타가 신선하고 밥 간도 딱 좋아요. 구로에서 초밥 먹을 땐 여기!', date: '2025-01-11', helpful: 29 },
-      { id: 'r105-3', author: '점심조', rating: 4, content: '우니 추가하면 완벽합니다. 혼밥하기에도 편한 분위기예요.', date: '2024-12-28', helpful: 17 },
-    ],
-    tags: ['초밥', '가성비', '런치'],
-    priceRange: '₩₩',
-    openHours: '11:00 - 22:00',
-    isHot: true,
-    area: '구로',
-    link: 'https://map.kakao.com',
-    images: [],
-  },
-
-  // ── 합정 / 마포 ──
   {
     id: '1',
     name: '스시코우지',
     lat: 37.5496,
     lng: 126.9139,
     category: '오마카세',
-    description: '합정 프리미엄 스시 오마카세',
+    description: '합정 프리미엄 스시 오마카세. 네타 하나하나가 녹아내리듯 신선해요. 샤리 온도까지 완벽한 오마카세!',
     address: '서울특별시 마포구 양화로 45',
     phone: '02-332-0037',
-
     rating: 4.9,
     reviewCount: 842,
     review: '네타 하나하나가 녹아내리듯 신선해요. 샤리 온도까지 완벽한 오마카세!',
-    reviews: [
-      { id: 'r1-1', author: '오마카세러', rating: 5, content: '네타 하나하나가 녹아내리듯 신선해요. 샤리 온도까지 완벽한 오마카세!', date: '2025-02-10', helpful: 89 },
-      { id: 'r1-2', author: '스시마니아', rating: 5, content: '합정에서 이 퀄리티 오마카세를 먹을 수 있다니. 예약 필수입니다.', date: '2025-01-30', helpful: 62 },
-      { id: 'r1-3', author: '기념일', rating: 5, content: '기념일에 갔는데 분위기도 좋고 셰프님이 하나하나 설명해주셔서 좋았어요.', date: '2025-01-15', helpful: 45 },
-      { id: 'r1-4', author: '미식가K', rating: 4, content: '가격은 좀 있지만 그만한 가치가 충분해요. 특히 대트로 추천!', date: '2024-12-20', helpful: 33 },
-    ],
     tags: ['오마카세', '예약필수', '데이트'],
     priceRange: '₩₩₩₩',
     openHours: '12:00 - 22:00',
     isHot: true,
     area: '합정',
     link: 'https://map.kakao.com',
-    images: [],
+    images: [getRandomImage('오마카세', 0)],
   },
-
-  // ── 용산 ──
   {
     id: '2',
     name: '몽탄',
     lat: 37.5282,
     lng: 126.9648,
     category: '한식',
-    description: '용산 숯불 고깃집',
+    description: '용산 숯불 고깃집. 숯불향이 배어든 갈비가 미쳤어요. 된장찌개도 깊은 맛!',
     address: '서울특별시 용산구 백범로99길 50',
     phone: '02-790-7070',
-
     rating: 4.7,
     reviewCount: 1253,
-    review: '숯불향이 배어든 갈비가 미쳤어요. 된장찌개도 깊은 맛이라 같이 먹으면 최고!',
-    reviews: [
-      { id: 'r2-1', author: '고기사랑', rating: 5, content: '숯불향이 배어든 갈비가 미쳤어요. 된장찌개도 깊은 맛이라 같이 먹으면 최고!', date: '2025-02-08', helpful: 78 },
-      { id: 'r2-2', author: '용산주민', rating: 5, content: '웨이팅 길지만 그만큼 맛있어요. 특히 항정살 숯불구이 강추!', date: '2025-01-22', helpful: 56 },
-      { id: 'r2-3', author: '데이트코스', rating: 4, content: '분위기도 좋고 고기도 맛있어서 데이트로 자주 가요.', date: '2025-01-05', helpful: 34 },
-    ],
+    review: '숯불향이 배어든 갈비가 미쳤어요. 된장찌개도 깊은 맛!',
     tags: ['숯불', '갈비', '웨이팅맛집'],
     priceRange: '₩₩₩',
     openHours: '17:00 - 23:00',
     isHot: true,
     area: '용산',
     link: 'https://map.kakao.com',
-    images: [],
-  },
-
-  // ── 한남 ──
-  {
-    id: '3',
-    name: '리스토란테 에오',
-    lat: 37.5344,
-    lng: 126.9977,
-    category: '양식',
-    description: '한남동 이탈리안 파인다이닝',
-    address: '서울특별시 용산구 이태원로55가길 26',
-    phone: '02-795-0105',
-
-    rating: 4.8,
-    reviewCount: 567,
-    review: '파스타 면의 질감이 남다르고, 소스 하나하나에 정성이 느껴지는 곳.',
-    reviews: [
-      { id: 'r3-1', author: '파스타러버', rating: 5, content: '파스타 면의 질감이 남다르고, 소스 하나하나에 정성이 느껴지는 곳.', date: '2025-02-03', helpful: 44 },
-      { id: 'r3-2', author: '와인매니아', rating: 5, content: '와인 리스트가 훌륭하고 소믈리에 추천도 정확해요. 코스 최고!', date: '2025-01-18', helpful: 37 },
-      { id: 'r3-3', author: '한남맛집러', rating: 4, content: '프로슈토 피자가 인상적이었어요. 다음엔 풀코스로 가볼 예정!', date: '2024-12-25', helpful: 21 },
-    ],
-    tags: ['파인다이닝', '파스타', '와인'],
-    priceRange: '₩₩₩₩',
-    openHours: '12:00 - 22:00',
-    isHot: true,
-    area: '한남',
-    link: 'https://map.kakao.com',
-    images: [],
-  },
-
-  // ── 강남 ──
-  {
-    id: '4',
-    name: '하카타분코',
-    lat: 37.5013,
-    lng: 127.0247,
-    category: '일식',
-    description: '강남 정통 하카타 라멘',
-    address: '서울특별시 강남구 강남대로102길 34',
-    phone: '02-567-8890',
-
-    rating: 4.5,
-    reviewCount: 923,
-    review: '진한 돈코츠 육수에 면 익힘까지 선택 가능! 교자도 꼭 시켜보세요.',
-    reviews: [
-      { id: 'r4-1', author: '라멘중독', rating: 5, content: '진한 돈코츠 육수에 면 익힘까지 선택 가능! 교자도 꼭 시켜보세요.', date: '2025-02-06', helpful: 52 },
-      { id: 'r4-2', author: '강남직장인', rating: 4, content: '점심에 라멘 한 그릇이면 오후가 행복해져요. 차슈가 두툼!', date: '2025-01-14', helpful: 28 },
-      { id: 'r4-3', author: '일본여행파', rating: 4, content: '일본 현지 느낌 나는 라멘. 국물이 진하면서도 느끼하지 않아요.', date: '2024-12-18', helpful: 19 },
-    ],
-    tags: ['라멘', '돈코츠', '점심맛집'],
-    priceRange: '₩₩',
-    openHours: '11:00 - 22:00',
-    isHot: false,
-    area: '강남',
-    link: 'https://map.kakao.com',
-    images: [],
-  },
-  {
-    id: '5',
-    name: '평양면옥',
-    lat: 37.4950,
-    lng: 127.0130,
-    category: '한식',
-    description: '서초 정통 평양냉면',
-    address: '서울특별시 서초구 서초대로74길 23',
-    phone: '02-585-1919',
-
-    rating: 4.6,
-    reviewCount: 1587,
-    review: '육수가 깔끔하고 면이 쫄깃해요. 여름에 한 그릇이면 더위가 싹 사라져요.',
-    reviews: [
-      { id: 'r5-1', author: '냉면킹', rating: 5, content: '육수가 깔끔하고 면이 쫄깃해요. 여름에 한 그릇이면 더위가 싹 사라져요.', date: '2025-01-30', helpful: 71 },
-      { id: 'r5-2', author: '서초주민', rating: 5, content: '20년째 다니는 단골입니다. 변치 않는 맛!', date: '2025-01-10', helpful: 48 },
-      { id: 'r5-3', author: '점심러', rating: 4, content: '만두도 맛있어요. 냉면+만두 조합 강추합니다.', date: '2024-12-15', helpful: 25 },
-    ],
-    tags: ['냉면', '전통맛집', '점심'],
-    priceRange: '₩₩',
-    openHours: '11:00 - 21:00',
-    isHot: false,
-    area: '서초',
-    link: 'https://map.kakao.com',
-    images: [],
+    images: [getRandomImage('한식', 2)],
   },
   {
     id: '6',
@@ -283,189 +154,56 @@ export const dummyPlaces: PlaceData[] = [
     lat: 37.5244,
     lng: 127.0382,
     category: '한식',
-    description: '미쉐린 2스타 한식 파인다이닝',
+    description: '미쉐린 2스타 한식 파인다이닝. 한식의 격을 다시 느끼게 해주는 곳. 코스 하나하나가 작품이에요.',
     address: '서울특별시 강남구 선릉로158길 11',
     phone: '02-517-4654',
-
     rating: 4.9,
     reviewCount: 2103,
     review: '한식의 격을 다시 느끼게 해주는 곳. 코스 하나하나가 작품이에요.',
-    reviews: [
-      { id: 'r6-1', author: '미쉐린헌터', rating: 5, content: '한식의 격을 다시 느끼게 해주는 곳. 코스 하나하나가 작품이에요.', date: '2025-02-12', helpful: 112 },
-      { id: 'r6-2', author: '특별한날', rating: 5, content: '프로포즈 장소로 완벽했어요. 분위기, 맛, 서비스 모두 최상급.', date: '2025-01-28', helpful: 89 },
-      { id: 'r6-3', author: '푸드블로거', rating: 5, content: '계절마다 바뀌는 코스가 매번 새로워요. 미쉐린 2스타 자격 충분!', date: '2025-01-08', helpful: 76 },
-      { id: 'r6-4', author: '외국인친구', rating: 4, content: '외국 친구 데려갔더니 감동받았어요. 한식의 매력을 보여주기 딱!', date: '2024-12-22', helpful: 54 },
-    ],
-    tags: ['미쉐린', '파인다이닝', '코스요리', '예약필수'],
+    tags: ['미쉐린', '파인다이닝', '코스요리'],
     priceRange: '₩₩₩₩',
-    openHours: '12:00 - 15:00, 18:00 - 22:00',
+    openHours: '12:00 - 22:00',
     isHot: true,
     area: '강남',
     link: 'https://map.kakao.com',
-    images: [],
+    images: [getRandomImage('한식', 0)],
   },
-  {
-    id: '7',
-    name: '도쿄등심',
-    lat: 37.5027,
-    lng: 127.0281,
-    category: '일식',
-    description: '강남 프리미엄 돈까스',
-    address: '서울특별시 강남구 테헤란로4길 31',
-    phone: '02-553-7799',
-
-    rating: 4.4,
-    reviewCount: 734,
-    review: '겉바속촉 그 자체! 히레까스 두께가 장난 아니고 소스도 맛있어요.',
-    reviews: [
-      { id: 'r7-1', author: '돈까스매니아', rating: 5, content: '겉바속촉 그 자체! 히레까스 두께가 장난 아니고 소스도 맛있어요.', date: '2025-01-22', helpful: 35 },
-      { id: 'r7-2', author: '강남맛집러', rating: 4, content: '로스까스도 추천! 양배추 리필에 밥도 넉넉해서 배부르게 먹을 수 있어요.', date: '2025-01-05', helpful: 21 },
-      { id: 'r7-3', author: '혼밥전문', rating: 4, content: '혼밥하기 좋은 분위기. 카운터석에서 바로 튀겨주는 모습이 멋져요.', date: '2024-12-10', helpful: 14 },
-    ],
-    tags: ['돈까스', '혼밥', '점심'],
-    priceRange: '₩₩',
-    openHours: '11:00 - 21:30',
-    isHot: false,
-    area: '강남',
-    link: 'https://map.kakao.com',
-    images: [],
-  },
-
-  // ── 청담 / 신사 ──
   {
     id: '8',
     name: '카페 노티드 청담',
     lat: 37.5196,
     lng: 127.0478,
     category: '카페',
-    description: '청담 시그니처 도넛 카페',
+    description: '청담 시그니처 도넛 카페. 우유크림 도넛은 무조건 먹어봐야 해요! 인테리어도 사진찍기 좋아요.',
     address: '서울특별시 강남구 도산대로53길 15',
     phone: '02-546-1009',
-
     rating: 4.3,
     reviewCount: 3241,
     review: '우유크림 도넛은 무조건 먹어봐야 해요! 인테리어도 사진찍기 좋아요.',
-    reviews: [
-      { id: 'r8-1', author: '도넛러버', rating: 5, content: '우유크림 도넛은 무조건 먹어봐야 해요! 인테리어도 사진찍기 좋아요.', date: '2025-02-01', helpful: 63 },
-      { id: 'r8-2', author: '카페투어러', rating: 4, content: '아이스 아메리카노와 슈가도넛 조합이 최고예요. 자리가 넓어서 좋아요.', date: '2025-01-17', helpful: 29 },
-      { id: 'r8-3', author: '인스타그래머', rating: 4, content: '포토존이 여러 군데 있어서 사진 찍기 좋아요. 맛도 물론 좋고!', date: '2024-12-28', helpful: 22 },
-    ],
     tags: ['도넛', '카페', '인스타감성'],
     priceRange: '₩₩',
     openHours: '10:00 - 22:00',
     isHot: false,
     area: '청담',
     link: 'https://map.kakao.com',
-    images: [],
-  },
-  {
-    id: '9',
-    name: '밀본',
-    lat: 37.5219,
-    lng: 127.0242,
-    category: '양식',
-    description: '신사동 수제 파스타',
-    address: '서울특별시 강남구 도산대로15길 32',
-    phone: '02-511-3366',
-
-    rating: 4.6,
-    reviewCount: 489,
-    review: '생면 파스타가 이렇게 맛있을 수 있나 싶어요. 봉골레 강력 추천!',
-    reviews: [
-      { id: 'r9-1', author: '파스타매니아', rating: 5, content: '생면 파스타가 이렇게 맛있을 수 있나 싶어요. 봉골레 강력 추천!', date: '2025-02-09', helpful: 38 },
-      { id: 'r9-2', author: '신사동맛집', rating: 5, content: '까르보나라가 정말 진해요. 빵도 직접 구워서 나오는데 버터 풍미가 대박.', date: '2025-01-20', helpful: 26 },
-      { id: 'r9-3', author: '데이트러', rating: 4, content: '데이트 코스로 완벽해요. 양도 적당하고 분위기가 아늑합니다.', date: '2025-01-03', helpful: 18 },
-    ],
-    tags: ['파스타', '생면', '데이트'],
-    priceRange: '₩₩₩',
-    openHours: '11:30 - 22:00',
-    isHot: false,
-    area: '신사',
-    link: 'https://map.kakao.com',
-    images: [],
+    images: [getRandomImage('카페', 1)],
   },
 
-  // ── 을지로 ──
-  {
-    id: '10',
-    name: '을지다락',
-    lat: 37.5660,
-    lng: 126.9905,
-    category: '한식',
-    description: '을지로 감성 한식 술집',
-    address: '서울특별시 중구 을지로 14길 8',
-    phone: '02-2267-0903',
-
-    rating: 4.5,
-    reviewCount: 678,
-    review: '한식 안주가 기가 막히고 을지로 감성이 물씬! 막걸리랑 찰떡궁합.',
-    reviews: [
-      { id: 'r10-1', author: '을지로감성', rating: 5, content: '한식 안주가 기가 막히고 을지로 감성이 물씬! 막걸리랑 찰떡궁합.', date: '2025-01-25', helpful: 41 },
-      { id: 'r10-2', author: '야근후한잔', rating: 4, content: '두부김치가 진짜 맛있어요. 직장인들 퇴근 후 가기 좋은 곳.', date: '2025-01-08', helpful: 23 },
-      { id: 'r10-3', author: '힙스터', rating: 5, content: '인테리어가 독특하고 메뉴 하나하나가 정성이 느껴져요.', date: '2024-12-20', helpful: 19 },
-    ],
-    tags: ['술집', '한식안주', '을지로감성'],
+  // 시뮬레이션 데이터
+  ...Array.from({ length: 20 }).map((_, i) => ({
+    id: `extra-${i}`,
+    name: `맛있는 식당 ${i + 1}`,
+    lat: 37.5 + (i * 0.005),
+    lng: 127.0 + (i * 0.005),
+    category: ['한식', '일식', '양식', '카페', '디저트'][i % 5],
+    description: `이곳은 아주 맛있는 식당 ${i + 1}입니다. 신선한 재료와 최고의 셰프가 선사하는 맛의 향연을 느껴보세요.`,
+    address: `서울시 어느구 어느동 ${i + 1}`,
+    rating: 4.0 + (i % 10) / 10,
+    reviewCount: 100 + (i * 27) % 900,
+    review: `정말 맛있어요! ${i + 1}번째 추천합니다.`,
+    tags: ['맛스타그램', '강추', '분위기맛집'],
+    area: ['강남', '성수', '합정', '을지로'][i % 4],
     priceRange: '₩₩',
-    openHours: '17:00 - 01:00',
-    isHot: false,
-    area: '을지로',
-    link: 'https://map.kakao.com',
-    images: [],
-  },
-
-  // ── 이태원 ──
-  {
-    id: '11',
-    name: '오스테리아 오르조',
-    lat: 37.5340,
-    lng: 126.9933,
-    category: '양식',
-    description: '이태원 이탈리안 레스토랑',
-    address: '서울특별시 용산구 이태원로 200',
-    phone: '02-797-8855',
-
-    rating: 4.7,
-    reviewCount: 412,
-    review: '트러플 리조또가 정말 진해요. 와인 페어링도 훌륭한 숨은 맛집!',
-    reviews: [
-      { id: 'r11-1', author: '리조또매니아', rating: 5, content: '트러플 리조또가 정말 진해요. 와인 페어링도 훌륭한 숨은 맛집!', date: '2025-02-04', helpful: 32 },
-      { id: 'r11-2', author: '이태원단골', rating: 5, content: '오너셰프가 직접 요리하시는데 퀄리티가 남달라요.', date: '2025-01-15', helpful: 24 },
-      { id: 'r11-3', author: '와인러버', rating: 4, content: '와인 리스트가 알차고 가격도 합리적이에요. 재방문 의사 200%!', date: '2024-12-30', helpful: 16 },
-    ],
-    tags: ['이탈리안', '리조또', '와인'],
-    priceRange: '₩₩₩',
-    openHours: '12:00 - 22:00',
-    isHot: false,
-    area: '이태원',
-    link: 'https://map.kakao.com',
-    images: [],
-  },
-
-  // ── 성수 ──
-  {
-    id: '12',
-    name: '원앤온리',
-    lat: 37.5445,
-    lng: 127.0557,
-    category: '카페',
-    description: '성수동 스페셜티 카페',
-    address: '서울특별시 성동구 서울숲2길 32',
-    phone: '02-461-2200',
-
-    rating: 4.4,
-    reviewCount: 1892,
-    review: '핸드드립 커피가 정말 부드럽고, 루프탑 뷰까지 완벽한 카페!',
-    reviews: [
-      { id: 'r12-1', author: '커피매니아', rating: 5, content: '핸드드립 커피가 정말 부드럽고, 루프탑 뷰까지 완벽한 카페!', date: '2025-02-07', helpful: 47 },
-      { id: 'r12-2', author: '성수탐험가', rating: 4, content: '원두가 매번 바뀌어서 올 때마다 새로운 맛을 즐길 수 있어요.', date: '2025-01-19', helpful: 31 },
-      { id: 'r12-3', author: '사진가', rating: 4, content: '루프탑에서 보는 서울숲 뷰가 정말 멋져요. 날 좋은 날 강추!', date: '2025-01-02', helpful: 22 },
-    ],
-    tags: ['스페셜티', '루프탑', '성수감성'],
-    priceRange: '₩₩',
-    openHours: '10:00 - 22:00',
-    isHot: false,
-    area: '성수',
-    link: 'https://map.kakao.com',
-    images: [],
-  },
+    images: [getRandomImage(['한식', '일식', '양식', '카페', '디저트'][i % 5], i)],
+  }))
 ];


### PR DESCRIPTION
- 반응형 2열 매거진 그리드로 PlaceListPage 리팩토링
- PlaceDetailCard에 슬라이드업(바텀시트) 상세 패널 구현
- 카테고리별 음식 이미지로 더미 데이터 업데이트
- 스티키 헤더, 필터 칩, 부드러운 애니메이션으로 UX 개선
- 결정적 더미 데이터 사용으로 하이드레이션 오류 수정
- 좌표 기반 카카오맵 딥링크 개선